### PR TITLE
Fix pep8 error in event.py

### DIFF
--- a/ryu/services/protocols/ovsdb/event.py
+++ b/ryu/services/protocols/ovsdb/event.py
@@ -81,4 +81,4 @@ class EventModifyReply(event.EventReplyBase):
 #                add((table, row_uuid, row))
 
 
-#handler.register_service('ryu.services.protocols.ovsdb.manager')
+# handler.register_service('ryu.services.protocols.ovsdb.manager')


### PR DESCRIPTION
Added a space next to the # symbol for pep 8 compliance
