### PR TITLE
Modified BGP Update logic to use the path nexthop value first

### DIFF
--- a/ryu/services/protocols/bgp/info_base/base.py
+++ b/ryu/services/protocols/bgp/info_base/base.py
@@ -805,6 +805,10 @@ class Path(object):
 
         return not interested_rts.isdisjoint(curr_rts)
 
+    def has_nexthop(self):
+        return not (not self._nexthop or self._nexthop == '0.0.0.0' or
+                    self._nexthop == '::')
+
     def __str__(self):
         return (
             'Path(source: %s, nlri: %s, source ver#: %s, '

--- a/ryu/services/protocols/bgp/peer.py
+++ b/ryu/services/protocols/bgp/peer.py
@@ -802,11 +802,15 @@ class Peer(Source, Sink, NeighborConfListener, Activity):
         """
         route_family = path.route_family
 
-        # By default we use BGPS's interface IP with this peer as next_hop.
-        if self._neigh_conf.next_hop:
+        # By default we use path's nexthop if has been set, else we check the
+        # BGPS's interface IP with this peer as next_hop.
+        if path.has_nexthop():
+            next_hop = path.nexthop
+        elif self._neigh_conf.next_hop:
             next_hop = self._neigh_conf.next_hop
         else:
             next_hop = self.host_bind_ip
+
         if route_family == RF_IPv6_VPN:
             next_hop = self._ipv4_mapped_ipv6(next_hop)
 


### PR DESCRIPTION
If the path has a next hop value set, it should be used in the BGP
Update message first.  This changes to logic to use the check for the
next hop in the order prefix/path->peer config->speaker config.  This
will allow for sending the nexthop as part of the add_prefix message and
allow for overiding the nexthop of the peer if one is set.
